### PR TITLE
Imitate sneaking behaviour for dispensers using wands.

### DIFF
--- a/src/main/java/vazkii/botania/common/block/BlockPistonRelay.java
+++ b/src/main/java/vazkii/botania/common/block/BlockPistonRelay.java
@@ -112,10 +112,13 @@ public class BlockPistonRelay extends BlockMod implements IWandable {
 
 	@Override
 	public boolean onUsedByWand(PlayerEntity player, ItemStack stack, World world, BlockPos pos, Direction side) {
-		if(player == null || world.isRemote)
+		if(world.isRemote)
 			return false;
 
-		if(!player.isSneaking()) {
+		if(player == null || player.isSneaking()) {
+			spawnAsEntity(world, pos, new ItemStack(this));
+			world.destroyBlock(pos, false);
+                } else {
 			GlobalPos clicked = GlobalPos.of(world.getDimension().getType(), pos.toImmutable());
 			if(ItemTwigWand.getBindMode(stack)) {
 				activeBindingAttempts.put(player.getUniqueID(), clicked);
@@ -129,9 +132,6 @@ public class BlockPistonRelay extends BlockMod implements IWandable {
 									dest.getPos().getX(), dest.getPos().getY(), dest.getPos().getZ()));
 				}
 			}
-		} else {
-			spawnAsEntity(world, pos, new ItemStack(this));
-			world.destroyBlock(pos, false);
 		}
 
 		return true;

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
@@ -198,10 +198,7 @@ public class SubTileHopperhock extends TileEntityFunctionalFlower {
 
 	@Override
 	public boolean onWanded(PlayerEntity player, ItemStack wand) {
-		if(player == null)
-			return false;
-
-		if(player.isSneaking()) {
+		if(player == null || player.isSneaking()) {
 			filterType = filterType == 2 ? 0 : filterType + 1;
 			sync();
 

--- a/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
@@ -372,10 +372,7 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 	}
 
 	public void onWanded(PlayerEntity player, ItemStack wand) {
-		if(player == null)
-			return;
-
-		if(player.isSneaking()) {
+		if(player == null || player.isSneaking()) {
 			outputting = !outputting;
 			VanillaPacketDispatcher.dispatchTEToNearbyPlayers(world, pos);
 		}

--- a/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
@@ -385,7 +385,11 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 				((ServerPlayerEntity) player).connection.sendPacket(new SUpdateTileEntityPacket(pos, -999, nbttagcompound));
 		}
 
-		world.playSound(null, player.posX, player.posY, player.posZ, ModSounds.ding, SoundCategory.PLAYERS, 0.11F, 1F);
+		if(player == null) {
+			world.playSound(null, getPos(), ModSounds.ding, SoundCategory.PLAYERS, 0.11F, 1F);
+		} else {
+			world.playSound(null, player.posX, player.posY, player.posZ, ModSounds.ding, SoundCategory.PLAYERS, 0.11F, 1F);
+		}
 	}
 
 	@OnlyIn(Dist.CLIENT)

--- a/src/main/java/vazkii/botania/common/block/tile/mana/TileTurntable.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TileTurntable.java
@@ -26,6 +26,7 @@ import net.minecraftforge.registries.ObjectHolder;
 import org.lwjgl.opengl.GL11;
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.common.block.tile.TileMod;
+import vazkii.botania.common.item.ItemTwigWand;
 import vazkii.botania.common.lib.LibBlockNames;
 import vazkii.botania.common.lib.LibMisc;
 
@@ -78,10 +79,7 @@ public class TileTurntable extends TileMod implements ITickableTileEntity {
 	}
 
 	public void onWanded(PlayerEntity player, ItemStack wand) {
-		if(player == null)
-			return;
-
-		if(player.isSneaking())
+		if((player != null && player.isSneaking()) || (player == null && !ItemTwigWand.getBindMode(wand))
 			backwards = !backwards;
 		else speed = speed == 6 ? 1 : speed + 1;
 		VanillaPacketDispatcher.dispatchTEToNearbyPlayers(world, pos);

--- a/src/main/java/vazkii/botania/common/block/tile/mana/TileTurntable.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TileTurntable.java
@@ -79,7 +79,7 @@ public class TileTurntable extends TileMod implements ITickableTileEntity {
 	}
 
 	public void onWanded(PlayerEntity player, ItemStack wand) {
-		if((player != null && player.isSneaking()) || (player == null && !ItemTwigWand.getBindMode(wand))
+		if((player != null && player.isSneaking()) || (player == null && !ItemTwigWand.getBindMode(wand)))
 			backwards = !backwards;
 		else speed = speed == 6 ? 1 : speed + 1;
 		VanillaPacketDispatcher.dispatchTEToNearbyPlayers(world, pos);


### PR DESCRIPTION
Dispensers lack the functionality of sneak-clicking things like mana pools and hopperhocks, which could be useful behaviours.